### PR TITLE
Initialize package structure

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,3 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+^LICENSE\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,14 @@
+Package: arcadiathemeR
+Type: Package
+Title: Create Illustrations that Adhere to Arcadia Science Style Guidelines
+Version: 0.1.0
+Author: Elizabeth McDaniel
+Maintainer: Elizabeth McDaniel <elizabeth.mcdaniel@arcadiascience.com>
+Description: This package adds themes and functions for creating plots
+    that adhere to Arcadia Science style guidelines. 
+License: MIT
+Encoding: UTF-8
+LazyData: true
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2024
+COPYRIGHT HOLDER: Arcadia Science

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2024 Arcadia Science
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,0 +1,1 @@
+exportPattern("^[[:alpha:]]+")

--- a/R/hello.R
+++ b/R/hello.R
@@ -1,0 +1,18 @@
+# Hello, world!
+#
+# This is an example function named 'hello' 
+# which prints 'Hello, world!'.
+#
+# You can learn more about package authoring with RStudio at:
+#
+#   http://r-pkgs.had.co.nz/
+#
+# Some useful keyboard shortcuts for package authoring:
+#
+#   Install Package:           'Cmd + Shift + B'
+#   Check Package:             'Cmd + Shift + E'
+#   Test Package:              'Cmd + Shift + T'
+
+hello <- function() {
+  print("Hello, world!")
+}

--- a/arcadiathemeR.Rproj
+++ b/arcadiathemeR.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/man/hello.Rd
+++ b/man/hello.Rd
@@ -1,0 +1,12 @@
+\name{hello}
+\alias{hello}
+\title{Hello, World!}
+\usage{
+hello()
+}
+\description{
+Prints 'Hello, world!'.
+}
+\examples{
+hello()
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(arcadiathemeR)
+
+test_check("arcadiathemeR")


### PR DESCRIPTION
I started the package how @taylorreiter created the sourmashconsumr package: https://github.com/Arcadia-Science/sourmashconsumr/pull/1
I used RStudio's File > New Project > New Directory > R package with the name arcadiathemeR. I added the license using the `use_mit_license()` function and started test infrastructure with the `use_testthat()`. I don't know how relevant tests will come into play with a plotting package, but I initiated it anyways. I edited the `Description` and `LICENSE` files for accurate descriptions and other information. The `hello.R` script and `man` were auto-generated with the package. These will be removed/modified in future PRs as I add functions. 

Immediate feedback I would like: 
- Are we fine with the name `arcadiathemeR`? R packages cannot have spaces or characters like `-` or `_`, it has to all be one word. They do allow capitalization, but I'm open to suggestions if it should just be `arcadiathemer` for example.