### PR TITLE
Allow package installation and usage with fallback fonts

### DIFF
--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -24,8 +24,6 @@
 #'   theme_arcadia()
 #' }
 
-source("load_fonts.R")
-
 theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", background = TRUE, padding = c(.25, .25, .25, .25)) {
 
   # font types
@@ -82,7 +80,6 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
 }
 
 # font constants
-FONT = get_font_family(extrafont::fonts(), "Suisse", "sans")
 REGULAR_FONT <- paste(FONT, "Int'l")
 SEMIBOLD_FONT <- paste(FONT, "Int'l Semi Bold")
 MEDIUM_FONT <- paste(FONT, "Int'l Medium")

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -75,11 +75,14 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
     # legend specifications
     legend.background = ggplot2::element_rect(fill = background_color, color = NA),
     plot.margin = ggplot2::unit(padding, "in")
-
-    )
+  )
 }
 
 # font constants
+FONT <- "Suisse"
+if (!(custom_font %in% available_fonts)) {
+  FONT <- system("fc-match -f '%%{family}' sans", intern = TRUE)
+}
 REGULAR_FONT <- paste(FONT, "Int'l")
 SEMIBOLD_FONT <- paste(FONT, "Int'l Semi Bold")
 MEDIUM_FONT <- paste(FONT, "Int'l Medium")

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -87,7 +87,6 @@ MEDIUM_FONT <- "Suisse Int'l Medium"
 MONO_FONT <- "Suisse Int'l Mono"
 
 # Use OS default sans fallback if Suisse is not installed
-FONT <- NULL
 if (!(REGULAR_FONT %in% extrafont::fonts())) {
   FONT <- system("fc-match -f '%{family}' sans", intern = TRUE)
   REGULAR_FONT <- FONT

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -95,6 +95,7 @@ AXIS_TITLE_FONT <- MEDIUM_FONT
 KEY_TITLE <- SEMIBOLD_FONT
 
 # Use OS default sans fallback if Suisse is not installed
+FONT <- NULL
 if (!("Suisse" %in% extrafont::fonts())) {
   FONT <- system("fc-match -f '%{family}' sans", intern = TRUE)
   REGULAR_FONT <- FONT

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -80,7 +80,7 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
 
 # font constants
 FONT <- "Suisse"
-if (!(FONT %in% available_fonts)) {
+if (!(FONT %in% extrafont::fonts())) {
   FONT <- system("fc-match -f '%%{family}' sans", intern = TRUE)
 }
 REGULAR_FONT <- paste(FONT, "Int'l")

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -88,7 +88,7 @@ MONO_FONT <- "Suisse Int'l Mono"
 
 # Use OS default sans fallback if Suisse is not installed
 FONT <- NULL
-if (!("Suisse" %in% extrafont::fonts())) {
+if (!(REGULAR_FONT %in% extrafont::fonts())) {
   FONT <- system("fc-match -f '%{family}' sans", intern = TRUE)
   REGULAR_FONT <- FONT
   SEMIBOLD_FONT <- FONT

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -24,6 +24,8 @@
 #'   theme_arcadia()
 #' }
 
+source("load_fonts.R")
+
 theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", background = TRUE, padding = c(.25, .25, .25, .25)) {
 
   # font types
@@ -80,10 +82,11 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
 }
 
 # font constants
-REGULAR_FONT <- "Suisse Int'l"
-SEMIBOLD_FONT <- "Suisse Int'l Semi Bold"
-MEDIUM_FONT <- "Suisse Int'l Medium"
-MONO_FONT <- "Suisse Int'l Mono"
+FONT = get_font_family(extrafont::fonts(), "Suisse", "sans")
+REGULAR_FONT <- paste(FONT, "Int'l")
+SEMIBOLD_FONT <- paste(FONT, "Int'l Semi Bold")
+MEDIUM_FONT <- paste(FONT, "Int'l Medium")
+MONO_FONT <- paste(FONT, "Int'l Mono")
 
 # axis label fonts which differ for categorical and numerical data
 CATEGORICAL_FONT <- REGULAR_FONT

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -39,16 +39,17 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
   y_axis_size <- if (y_axis_type == "categorical") 15 else 14.5
 
   # axis ticks
-  x_axis_ticks <- if (x_axis_type == "categorical") ggplot2::element_blank() else ggplot2::element_line(color="black", size = 0.35) # size ratio to pts is 2.13, so .75 in pts is .35 here
-  y_axis_ticks <- if (y_axis_type == "categorical") ggplot2::element_blank() else ggplot2::element_line(color="black", size = 0.35) # size ratio to pts is 2.13, so .75 in pts is .35 here
+  # size ratio to pts is 2.13, so .75 in pts is .35 here
+  x_axis_ticks <- if (x_axis_type == "categorical") ggplot2::element_blank() else ggplot2::element_line(color="black", size = 0.35)
+  # size ratio to pts is 2.13, so .75 in pts is .35 here
+  y_axis_ticks <- if (y_axis_type == "categorical") ggplot2::element_blank() else ggplot2::element_line(color="black", size = 0.35)
 
   # background fill
   background_color <- if (background == TRUE) BACKGROUND_FILL else 'transparent'
 
   ggplot2::theme_minimal() +
-
-    # font specifications
   ggplot2::theme(
+    # font specifications
     plot.title = ggplot2::element_text(family = REGULAR_FONT, size = 16, face = "bold"),
     axis.title.x = ggplot2::element_text(family = x_axis_label_family, size = 15, vjust = -1),
     axis.title.y = ggplot2::element_text(family = y_axis_label_family, size = 15, vjust = +2),
@@ -56,7 +57,6 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
     axis.text.y = ggplot2::element_text(family = y_axis_family, size = y_axis_size, color = "black"),
     legend.title = ggplot2::element_text(family = legend_label_family, size = 16),
     legend.text = ggplot2::element_text(family = legend_text_family, size = 15),
-
 
     # background specifications
     plot.background = ggplot2::element_rect(fill = background_color, color = NA),
@@ -68,9 +68,11 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
     # tick specifications
     axis.ticks.x = x_axis_ticks,
     axis.ticks.y = y_axis_ticks,
-    axis.ticks.length.x = ggplot2::unit(0.07, "in"), # 5 pixels is roughly 0.07 inches
+    # 5 pixels is roughly 0.07 inches
+    axis.ticks.length.x = ggplot2::unit(0.07, "in"),
     axis.ticks.length.y = ggplot2::unit(0.07, "in"),
-    axis.line = ggplot2::element_line(color="black", size=0.35), # size ratio to pts is 2.13, so .75 in pts is .35 here
+    # size ratio to pts is 2.13, so .75 in pts is .35 here
+    axis.line = ggplot2::element_line(color="black", size=0.35),
 
     # legend specifications
     legend.background = ggplot2::element_rect(fill = background_color, color = NA),
@@ -79,14 +81,10 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
 }
 
 # font constants
-FONT <- "Suisse"
-if (!(FONT %in% extrafont::fonts())) {
-  FONT <- system("fc-match -f '%{family}' sans", intern = TRUE)
-}
-REGULAR_FONT <- sprintf("%s Int'l", FONT)
-SEMIBOLD_FONT <- sprintf("%s Int'l Semi Bold", FONT)
-MEDIUM_FONT <- sprintf("%s Int'l Medium", FONT)
-MONO_FONT <- sprintf("%s Int'l Mono", FONT)
+REGULAR_FONT <- "Suisse Int'l"
+SEMIBOLD_FONT <- "Suisse Int'l Semi Bold"
+MEDIUM_FONT <- "Suisse Int'l Medium"
+MONO_FONT <- "Suisse Int'l Mono"
 
 # axis label fonts which differ for categorical and numerical data
 CATEGORICAL_FONT <- REGULAR_FONT
@@ -95,6 +93,19 @@ NUMERICAL_FONT <- MONO_FONT
 # main font types
 AXIS_TITLE_FONT <- MEDIUM_FONT
 KEY_TITLE <- SEMIBOLD_FONT
+
+# Use OS default sans fallback if Suisse is not installed
+if (!(FONT %in% extrafont::fonts())) {
+  FONT <- system("fc-match -f '%{family}' sans", intern = TRUE)
+  REGULAR_FONT <- FONT
+  SEMIBOLD_FONT <- FONT
+  MEDIUM_FONT <- FONT
+  MONO_FONT <- FONT
+  CATEGORICAL_FONT <- FONT
+  NUMERICAL_FONT <- FONT
+  AXIS_TITLE_FONT <- FONT
+  KEY_TITLE <- FONT
+}
 
 # background fill options
 BACKGROUND_FILL <- "#FDF8F2"

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -83,10 +83,10 @@ FONT <- "Suisse"
 if (!(FONT %in% extrafont::fonts())) {
   FONT <- system("fc-match -f '%%{family}' sans", intern = TRUE)
 }
-REGULAR_FONT <- paste(FONT, "Int'l")
-SEMIBOLD_FONT <- paste(FONT, "Int'l Semi Bold")
-MEDIUM_FONT <- paste(FONT, "Int'l Medium")
-MONO_FONT <- paste(FONT, "Int'l Mono")
+REGULAR_FONT <- sprintf("%s Int'l", FONT)
+SEMIBOLD_FONT <- sprintf("%s Int'l Semi Bold", FONT)
+MEDIUM_FONT <- sprintf("%s Int'l Medium", FONT)
+MONO_FONT <- sprintf("%s Int'l Mono", FONT)
 
 # axis label fonts which differ for categorical and numerical data
 CATEGORICAL_FONT <- REGULAR_FONT

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -95,7 +95,7 @@ AXIS_TITLE_FONT <- MEDIUM_FONT
 KEY_TITLE <- SEMIBOLD_FONT
 
 # Use OS default sans fallback if Suisse is not installed
-if (!(FONT %in% extrafont::fonts())) {
+if (!("Suisse" %in% extrafont::fonts())) {
   FONT <- system("fc-match -f '%{family}' sans", intern = TRUE)
   REGULAR_FONT <- FONT
   SEMIBOLD_FONT <- FONT

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -80,7 +80,7 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
 
 # font constants
 FONT <- "Suisse"
-if (!(custom_font %in% available_fonts)) {
+if (!(FONT %in% available_fonts)) {
   FONT <- system("fc-match -f '%%{family}' sans", intern = TRUE)
 }
 REGULAR_FONT <- paste(FONT, "Int'l")

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -81,7 +81,7 @@ theme_arcadia <- function(x_axis_type = "numerical", y_axis_type = "numerical", 
 # font constants
 FONT <- "Suisse"
 if (!(FONT %in% extrafont::fonts())) {
-  FONT <- system("fc-match -f '%%{family}' sans", intern = TRUE)
+  FONT <- system("fc-match -f '%{family}' sans", intern = TRUE)
 }
 REGULAR_FONT <- sprintf("%s Int'l", FONT)
 SEMIBOLD_FONT <- sprintf("%s Int'l Semi Bold", FONT)

--- a/R/arcadia.R
+++ b/R/arcadia.R
@@ -86,14 +86,6 @@ SEMIBOLD_FONT <- "Suisse Int'l Semi Bold"
 MEDIUM_FONT <- "Suisse Int'l Medium"
 MONO_FONT <- "Suisse Int'l Mono"
 
-# axis label fonts which differ for categorical and numerical data
-CATEGORICAL_FONT <- REGULAR_FONT
-NUMERICAL_FONT <- MONO_FONT
-
-# main font types
-AXIS_TITLE_FONT <- MEDIUM_FONT
-KEY_TITLE <- SEMIBOLD_FONT
-
 # Use OS default sans fallback if Suisse is not installed
 FONT <- NULL
 if (!("Suisse" %in% extrafont::fonts())) {
@@ -102,11 +94,15 @@ if (!("Suisse" %in% extrafont::fonts())) {
   SEMIBOLD_FONT <- FONT
   MEDIUM_FONT <- FONT
   MONO_FONT <- FONT
-  CATEGORICAL_FONT <- FONT
-  NUMERICAL_FONT <- FONT
-  AXIS_TITLE_FONT <- FONT
-  KEY_TITLE <- FONT
 }
+
+# axis label fonts which differ for categorical and numerical data
+CATEGORICAL_FONT <- REGULAR_FONT
+NUMERICAL_FONT <- MONO_FONT
+
+# main font types
+AXIS_TITLE_FONT <- MEDIUM_FONT
+KEY_TITLE <- SEMIBOLD_FONT
 
 # background fill options
 BACKGROUND_FILL <- "#FDF8F2"

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -1,3 +1,4 @@
+
 #' Load in custom fonts
 #'
 #' @param custom_font Font family name to be loaded in
@@ -11,8 +12,11 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
 
   # import and load fonts
-  invisible(utils::capture.output(extrafont::font_import(pattern = custom_font, prompt = FALSE)))
-  invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
+  # supress messages, below will handle incorrect loading
+  suppressMessages({
+    invisible(utils::capture.output(extrafont::font_import(prompt = FALSE)))
+    invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
+  })
 
   # check if custom font available
   available_fonts <- extrafont::fonts()

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -8,10 +8,9 @@
 #'
 load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   # check if custom font available
-  available_fonts <- extrafont::fonts()
   font_family <- custom_font
 
-  if (!(custom_font %in% available_fonts)) {
+  if (!(custom_font %in% extrafont::fonts())) {
     font_family <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
     # Ubuntu returns "DejaVu Sans" while R looks for "DejaVuSans", so remove spaces
     if (Sys.info()["sysname"] == "Linux") {
@@ -28,6 +27,7 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
 
   # define font names to check for
   font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
+  available_fonts <- extrafont::fonts()
   missing_fonts <- setdiff(font_names, available_fonts)
 
   if (length(missing_fonts) == 0) {

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -10,26 +10,23 @@
 load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   # define font names to check for
   font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
-  default_sans_font <- system("fc-match -f '%{family}' sans", intern = TRUE)
+  default_fallback_font <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
 
   # import and load fonts
-  # supress messages, below will handle incorrect loading
+  # suppress messages, below will handle incorrect loading
+  available_fonts <- extrafont::fonts()
+
   suppressMessages({
-    tryCatch(
-      {
-        invisible(utils::capture.output(extrafont::font_import(pattern = custom_font, prompt = FALSE)))
-      },
-      error = function(e) {
-        invisible(utils::capture.output(extrafont::font_import(pattern = default_sans_font, prompt = FALSE)))
-      },
-      finally = {
-        invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
-      }
-    )
+    available_fonts <- extrafont::fonts()
+    font_to_import <- custom_font
+    if (!(custom_font %in% available_fonts)) {
+      font_to_import <- default_fallback_font
+    }
+    invisible(utils::capture.output(extrafont::font_import(pattern = font_to_import, prompt = FALSE)))
+    invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
   })
 
   # check if custom font available
-  available_fonts <- extrafont::fonts()
   missing_fonts <- setdiff(font_names, available_fonts)
   if (length(missing_fonts) == 0) {
     cat(sprintf("All custom fonts '%s' are successfully loaded.\n", paste(font_names, collapse = ", ")))

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -10,7 +10,7 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   # check if custom font available
   font_family <- custom_font
 
-  if (!(custom_font %in% extrafont::fonts())) {
+  if (!("Suisse Int'l" %in% extrafont::fonts())) {
     font_family <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
     # Ubuntu returns "DejaVu Sans" while R looks for "DejaVuSans", so remove spaces
     if (Sys.info()["sysname"] == "Linux") {

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -1,22 +1,3 @@
-#' Get font family
-#'
-#' This function returns the font family to be used. It checks if the custom font is available in the list of available fonts. If the custom font is not available, it uses a fallback font.
-#'
-#' @param available_fonts Available font names.
-#' @param custom_font Custom font family name to be used.
-#' @param fallback_font Fallback font family name to be used in case custom font is not available.
-#' 
-#' @return Font family to be used in plots.
-#' @export
-#'
-get_font_family <- function(available_fonts, custom_font = "Suisse", fallback_font = "sans") {
-  if (!(custom_font %in% available_fonts)) {
-    font_family <- system(sprintf("fc-match -f '%%{family}' %s", font_family), intern = TRUE)
-    return(font_family)
-  }
-  return(custom_font)
-}
-
 #' Load in custom fonts
 #'
 #' @param custom_font Font family name to be loaded in
@@ -26,10 +7,12 @@ get_font_family <- function(available_fonts, custom_font = "Suisse", fallback_fo
 #' @export
 #'
 load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
-  # define font names to check for
+  # check if custom font available
   available_fonts <- extrafont::fonts()
-  font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
-  font_family = get_font_family(available_fonts, custom_font, fallback_font)
+  font_family <- custom_font
+  if (!(custom_font %in% available_fonts)) {
+    font_family <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
+  }
 
   # import and load fonts
   # suppress messages, below will handle incorrect loading
@@ -38,8 +21,10 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
     invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
   })
 
-  # check if custom font available
+  # define font names to check for
+  font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
   missing_fonts <- setdiff(font_names, available_fonts)
+
   if (length(missing_fonts) == 0) {
     cat(sprintf("All custom fonts '%s' are successfully loaded.\n", paste(font_names, collapse = ", ")))
     return(font_names)

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -10,13 +10,13 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   # check if custom font available
   available_fonts <- extrafont::fonts()
   font_family <- custom_font
+
   if (!(custom_font %in% available_fonts)) {
     font_family <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
-  }
-
-  # Ubuntu returns "DejaVu Sans" while R looks for "DejaVuSans", so remove spaces
-  if (Sys.info()["sysname"] == "Linux") {
-    font_family <- gsub(" ", "", font_family)
+    # Ubuntu returns "DejaVu Sans" while R looks for "DejaVuSans", so remove spaces
+    if (Sys.info()["sysname"] == "Linux") {
+      font_family <- gsub(" ", "", font_family)
+    }
   }
 
   # import and load fonts

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -10,11 +10,13 @@
 load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   # define font names to check for
   font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
+  default_sans_font <- system("fc-match -f '%{family}' sans", intern = TRUE)
 
   # import and load fonts
   # supress messages, below will handle incorrect loading
   suppressMessages({
-    invisible(utils::capture.output(extrafont::font_import(prompt = FALSE)))
+    invisible(utils::capture.output(extrafont::font_import(pattern = custom_font, prompt = FALSE)))
+    invisible(utils::capture.output(extrafont::font_import(pattern = default_sans_font, prompt = FALSE)))
     invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
   })
 

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -1,4 +1,3 @@
-
 #' Load in custom fonts
 #'
 #' @param custom_font Font family name to be loaded in
@@ -12,11 +11,8 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
 
   # import and load fonts
-  # supress messages, below will handle incorrect loading
-  suppressMessages({
-    invisible(utils::capture.output(extrafont::font_import(pattern = custom_font, prompt = FALSE)))
-    invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
-  })
+  invisible(utils::capture.output(extrafont::font_import(pattern = custom_font, prompt = FALSE)))
+  invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
 
   # check if custom font available
   available_fonts <- extrafont::fonts()

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -14,6 +14,11 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
     font_family <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
   }
 
+  # Ubuntu returns "DejaVu Sans" while R looks for "DejaVuSans", so remove spaces
+  if (Sys.info()["sysname"] == "Linux") {
+    font_family <- gsub(" ", "", font_family)
+  }
+
   # import and load fonts
   # suppress messages, below will handle incorrect loading
   suppressMessages({

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -1,32 +1,31 @@
 #' Load in custom fonts
 #'
-#' @param custom_font Font family name to be loaded in
+#' @param font Font family name to be loaded in
 #' @param fallback_font Font family name to be used in case custom font not available
 #'
 #' @return Custom font families or fallback font to use in plots.
 #' @export
 #'
-load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
-  # check if custom font available
-  font_family <- custom_font
+load_arcadia_fonts <- function(font = "Suisse", fallback_font = "sans") {
+  # Check if custom font is installed on the system
+  # If not installed, use the OS default fallback font
+  font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
 
-  if (!("Suisse Int'l" %in% extrafont::fonts())) {
-    font_family <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
+  if (!(font_names[1] %in% extrafont::fonts())) {
+    font <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
     # Ubuntu returns "DejaVu Sans" while R looks for "DejaVuSans", so remove spaces
     if (Sys.info()["sysname"] == "Linux") {
-      font_family <- gsub(" ", "", font_family)
+      font <- gsub(" ", "", font)
     }
   }
 
-  # import and load fonts
-  # suppress messages, below will handle incorrect loading
+  # Import and load fonts
   suppressMessages({
-    invisible(utils::capture.output(extrafont::font_import(pattern = font_family, prompt = FALSE)))
+    invisible(utils::capture.output(extrafont::font_import(pattern = font, prompt = FALSE)))
     invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
   })
 
-  # define font names to check for
-  font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
+  # Check if custom fonts were successfully loaded
   available_fonts <- extrafont::fonts()
   missing_fonts <- setdiff(font_names, available_fonts)
 

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -1,3 +1,21 @@
+#' Get font family
+#'
+#' This function returns the font family to be used. It checks if the custom font is available in the list of available fonts. If the custom font is not available, it uses a fallback font.
+#'
+#' @param available_fonts Available font names.
+#' @param custom_font Custom font family name to be used.
+#' @param fallback_font Fallback font family name to be used in case custom font is not available.
+#' 
+#' @return Font family to be used in plots.
+#' @export
+#'
+get_font_family <- function(available_fonts, custom_font = "Suisse", fallback_font = "sans") {
+  if (!(custom_font %in% available_fonts)) {
+    font_family <- system(sprintf("fc-match -f '%%{family}' %s", font_family), intern = TRUE)
+    return(font_family)
+  }
+  return(custom_font)
+}
 
 #' Load in custom fonts
 #'
@@ -9,19 +27,14 @@
 #'
 load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   # define font names to check for
+  available_fonts <- extrafont::fonts()
   font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
-  default_fallback_font <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
+  font_family = get_font_family(available_fonts, custom_font, fallback_font)
 
   # import and load fonts
   # suppress messages, below will handle incorrect loading
-  available_fonts <- extrafont::fonts()
-
   suppressMessages({
-    font_to_import <- custom_font
-    if (!(custom_font %in% available_fonts)) {
-      font_to_import <- default_fallback_font
-    }
-    invisible(utils::capture.output(extrafont::font_import(pattern = font_to_import, prompt = FALSE)))
+    invisible(utils::capture.output(extrafont::font_import(pattern = font_family, prompt = FALSE)))
     invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
   })
 

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -1,31 +1,37 @@
 #' Load in custom fonts
 #'
-#' @param font Font family name to be loaded in
+#' @param custom_font Font family name to be loaded in
 #' @param fallback_font Font family name to be used in case custom font not available
 #'
 #' @return Custom font families or fallback font to use in plots.
 #' @export
 #'
-load_arcadia_fonts <- function(font = "Suisse", fallback_font = "sans") {
-  # Check if custom font is installed on the system
-  # If not installed, use the OS default fallback font
-  font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
-
-  if (!(font_names[1] %in% extrafont::fonts())) {
-    font <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
-    # Ubuntu returns "DejaVu Sans" while R looks for "DejaVuSans", so remove spaces
-    if (Sys.info()["sysname"] == "Linux") {
-      font <- gsub(" ", "", font)
-    }
-  }
-
+load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   # Import and load fonts
   suppressMessages({
-    invisible(utils::capture.output(extrafont::font_import(pattern = font, prompt = FALSE)))
-    invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
+    tryCatch(
+      # Try to import custom font
+      {
+        invisible(utils::capture.output(extrafont::font_import(pattern = custom_font, prompt = FALSE)))
+      },
+      # If custom font is not found, import the OS default for fallback font
+      error = function(e) {
+        font <- system(sprintf("fc-match -f '%%{family}' %s", fallback_font), intern = TRUE)
+        # Ubuntu returns "DejaVu Sans" while R looks for "DejaVuSans", so remove spaces
+        if (Sys.info()["sysname"] == "Linux") {
+          font <- gsub(" ", "", font)
+        }
+        invisible(utils::capture.output(extrafont::font_import(pattern = font, prompt = FALSE)))
+      },
+      # Once imported, load fonts
+      finally = {
+        invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
+      }
+    )
   })
 
   # Check if custom fonts were successfully loaded
+  font_names <- c("Suisse Int'l", "Suisse Int'l Semi Bold", "Suisse Int'l Medium", "Suisse Int'l Mono")
   available_fonts <- extrafont::fonts()
   missing_fonts <- setdiff(font_names, available_fonts)
 

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -15,9 +15,17 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   # import and load fonts
   # supress messages, below will handle incorrect loading
   suppressMessages({
-    invisible(utils::capture.output(extrafont::font_import(pattern = custom_font, prompt = FALSE)))
-    invisible(utils::capture.output(extrafont::font_import(pattern = default_sans_font, prompt = FALSE)))
-    invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
+    tryCatch(
+      {
+        invisible(utils::capture.output(extrafont::font_import(pattern = custom_font, prompt = FALSE)))
+      },
+      error = function(e) {
+        invisible(utils::capture.output(extrafont::font_import(pattern = default_sans_font, prompt = FALSE)))
+      },
+      finally = {
+        invisible(utils::capture.output(extrafont::loadfonts(device = "pdf", quiet = TRUE)))
+      }
+    )
   })
 
   # check if custom font available

--- a/R/load_fonts.R
+++ b/R/load_fonts.R
@@ -17,7 +17,6 @@ load_arcadia_fonts <- function(custom_font = "Suisse", fallback_font = "sans") {
   available_fonts <- extrafont::fonts()
 
   suppressMessages({
-    available_fonts <- extrafont::fonts()
     font_to_import <- custom_font
     if (!(custom_font %in% available_fonts)) {
       font_to_import <- default_fallback_font

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -2,5 +2,5 @@
   # startup message
   base::packageStartupMessage("Loading Suisse fonts...")
   # define exact fonts to load and check for
-  load_arcadia_fonts()
+  # load_arcadia_fonts()
 }

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -2,5 +2,5 @@
   # startup message
   base::packageStartupMessage("Loading Suisse fonts...")
   # define exact fonts to load and check for
-  # load_arcadia_fonts()
+  load_arcadia_fonts()
 }

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -2,5 +2,6 @@
   # startup message
   base::packageStartupMessage("Loading Suisse fonts...")
   # define exact fonts to load and check for
+  FONT <- get_font_family(extrafont::fonts(), "Suisse", "sans")
   load_arcadia_fonts()
 }

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -1,7 +1,6 @@
 .onAttach <- function(libname, pkgname) {
   # startup message
-  base::packageStartupMessage("Loading Suisse fonts...")
+  base::packageStartupMessage("Loading fonts...")
   # define exact fonts to load and check for
-  FONT <- get_font_family(extrafont::fonts(), "Suisse", "sans")
   load_arcadia_fonts()
 }


### PR DESCRIPTION
## Summary
Fixes #39, in which the following error was thrown on package installation:
```
Error: package or namespace load failed for ‘arcadiathemeR’:
 .onAttach failed in attachNamespace() for 'arcadiathemeR', details:
  call: data.frame(fontfile = ttfiles, FontName = "", stringsAsFactors = FALSE)
  error: arguments imply differing number of rows: 0, 1
```

This error was occurring because `load_fonts.R` was trying to import "Suisse" as a font regardless of whether it existed or not.
```R
font_import(pattern = "Suisse", prompt = FALSE)
```

This PR imports the system default fallback font(s) if "Suisse" is not available, which fixes the installation error. However, upon usage, I discovered that the Suisse fonts had been hardcoded in, so I had to dynamically set those as well. I'm not familiar with R so please let me know if there's a more optimal approach.

## Checklist

- [x] Fix installation error due to import of unavailable custom font
- [x] Use fallback sans font in plots if custom font is unavailable
- [x] Test install and usage on macOS and Linux platforms